### PR TITLE
fix: handled ID length > 6

### DIFF
--- a/src/datalogger/src/datalogger/payloads.rs
+++ b/src/datalogger/src/datalogger/payloads.rs
@@ -1,4 +1,5 @@
 use alloc::fmt::Debug;
+use rtt_target::rprint;
 use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
 
@@ -156,7 +157,10 @@ impl SensorSetPayload {
             match payload_id {
                 serde_json::Value::String(id) => {
                     let mut prepared_id: [u8; 6] = [0; 6];
-                    prepared_id[0..id.len()].copy_from_slice(id.as_bytes());
+                    if id.len() > 6 {
+                        rprint!("WARNING: Sensor id too long, truncating to 6 characters.\n");
+                    }
+                    prepared_id[0..id.len().min(6)].copy_from_slice(&id.as_bytes()[0..id.len().min(6)]);
                     sensor_id = Some(prepared_id);
                 }
                 _ => {


### PR DESCRIPTION
Previously, the firmware used to crash if the sensor ID is more than 6 characters. Now it issues a warning to the user and truncates the ID to the first 6 characters.